### PR TITLE
Accept AddressResolvers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 scala:
-  - 2.11.8
-  - 2.12.1
+  - 2.11.12
+  - 2.12.5
 jdk:
   - oraclejdk8
 services:

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ way, if your consumer fails to process the request or is disconnected, the broke
   }
   // wait 10 seconds and shut down
   Thread.sleep(10000)
-  system.shutdown()
+  system.terminate()
 
 ```
 
@@ -336,7 +336,7 @@ This is very useful if you want to break a single operation into multiple, paral
   }
   // wait 10 seconds and shut down
   Thread.sleep(10000)
-  system.shutdown()
+  system.terminate()
 
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,23 +4,23 @@ organization := "eu.shiftforward"
 
 version := "1.6.2-SNAPSHOT"
 
-scalaVersion := "2.12.1"
+scalaVersion := "2.12.5"
 
-crossScalaVersions := Seq("2.11.8", "2.12.1")
+crossScalaVersions := Seq("2.11.12", "2.12.5")
 
 scalacOptions ++= Seq("-feature", "-language:postfixOps")
 
 resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies ++= {
-  val akkaVersion = "2.4.17"
+  val akkaVersion = "2.5.11"
   Seq(
-    "com.rabbitmq"         % "amqp-client"          % "4.1.0",
+    "com.rabbitmq"         % "amqp-client"          % "5.2.0",
     "com.typesafe.akka"    %% "akka-actor"          % akkaVersion % "provided",
     "com.typesafe.akka"    %% "akka-slf4j"          % akkaVersion % "test",
     "com.typesafe.akka"    %% "akka-testkit"        % akkaVersion % "test",
-    "org.scalatest"        %% "scalatest"           % "3.0.1" % "test",
-    "ch.qos.logback"       % "logback-classic"      % "1.2.1" % "test",
+    "org.scalatest"        %% "scalatest"           % "3.0.5" % "test",
+    "ch.qos.logback"       % "logback-classic"      % "1.2.3" % "test",
     "junit"           	   % "junit"                % "4.12" % "test"
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.1.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,1 @@
-resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
-
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
-
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.4")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")

--- a/src/main/scala/com/github/sstone/amqp/Amqp.scala
+++ b/src/main/scala/com/github/sstone/amqp/Amqp.scala
@@ -91,8 +91,6 @@ object Amqp {
 
   case class AddShutdownListener(listener: ActorRef) extends Request
 
-  case class AddFlowListener(listener: ActorRef) extends Request
-
   case class Close(code: Int = AMQP.REPLY_SUCCESS, message: String = "OK", timeout: Int = -1) extends Request
 
   case class DeclareQueue(queue: QueueParameters) extends Request

--- a/src/main/scala/com/github/sstone/amqp/ChannelOwner.scala
+++ b/src/main/scala/com/github/sstone/amqp/ChannelOwner.scala
@@ -2,7 +2,7 @@ package com.github.sstone.amqp
 
 import collection.JavaConversions._
 import com.rabbitmq.client.AMQP.BasicProperties
-import com.rabbitmq.client._
+import com.rabbitmq.client.{Delivery => _, _}
 import akka.actor._
 import com.github.sstone.amqp.Amqp._
 import scala.util.Try
@@ -46,11 +46,6 @@ object ChannelOwner {
           def handleReturn(replyCode: Int, replyText: String, exchange: String, routingKey: String, properties: BasicProperties, body: Array[Byte]) {
             listener ! ReturnedMessage(replyCode, replyText, exchange, routingKey, properties, body)
           }
-        }))
-      }
-      case request@AddFlowListener(listener) => {
-        sender ! withChannel(channel, request)(c => c.addFlowListener(new FlowListener {
-          def handleFlow(active: Boolean): Unit = listener ! HandleFlow(active)
         }))
       }
       case request@Publish(exchange, routingKey, body, properties, mandatory, immediate) => {

--- a/src/main/scala/com/github/sstone/amqp/samples/Admin.scala
+++ b/src/main/scala/com/github/sstone/amqp/samples/Admin.scala
@@ -31,7 +31,7 @@ class AdminActor extends Actor {
   def connected(channel: ActorRef) : Receive = {
     case Amqp.Ok(request: DeclareQueue, Some(result: Queue.DeclareOk)) => {
       println(s"there are ${result.getMessageCount} in queue ${result.getQueue}")
-      context.system.shutdown()
+      context.system.terminate()
     }
   }
 }

--- a/src/main/scala/com/github/sstone/amqp/samples/Consumer1.scala
+++ b/src/main/scala/com/github/sstone/amqp/samples/Consumer1.scala
@@ -52,5 +52,5 @@ object Consumer1 extends App {
   println("press enter...")
 
   System.in.read()
-  system.shutdown()
+  system.terminate()
 }

--- a/src/main/scala/com/github/sstone/amqp/samples/Consumer2.scala
+++ b/src/main/scala/com/github/sstone/amqp/samples/Consumer2.scala
@@ -40,5 +40,5 @@ object Consumer2 extends App {
   // run the Producer sample now and see what happens
   println("press enter...")
   System.in.read()
-  system.shutdown()
+  system.terminate()
 }

--- a/src/main/scala/com/github/sstone/amqp/samples/Consumer3.scala
+++ b/src/main/scala/com/github/sstone/amqp/samples/Consumer3.scala
@@ -39,5 +39,5 @@ object Consumer3 extends App {
   // run the Producer sample now and see what happens
   println("press enter...")
   System.in.read()
-  system.shutdown()
+  system.terminate()
 }

--- a/src/main/scala/com/github/sstone/amqp/samples/OneToAnyRpc.scala
+++ b/src/main/scala/com/github/sstone/amqp/samples/OneToAnyRpc.scala
@@ -67,5 +67,5 @@ object OneToAnyRpc extends App {
   }
   // wait 10 seconds and shut down
   Thread.sleep(10000)
-  system.shutdown()
+  system.terminate()
 }

--- a/src/main/scala/com/github/sstone/amqp/samples/OneToManyRpc.scala
+++ b/src/main/scala/com/github/sstone/amqp/samples/OneToManyRpc.scala
@@ -73,5 +73,5 @@ object OneToManyRpc extends App {
   }
   // wait 10 seconds and shut down
   Thread.sleep(10000)
-  system.shutdown()
+  system.terminate()
 }

--- a/src/main/scala/com/github/sstone/amqp/samples/Producer.scala
+++ b/src/main/scala/com/github/sstone/amqp/samples/Producer.scala
@@ -25,5 +25,5 @@ object Producer extends App {
 
   // give it some time before shutting everything down
   Thread.sleep(500)
-  system.shutdown()
+  system.terminate()
 }

--- a/src/test/scala/com/github/sstone/amqp/ConnectionOwnerSpec.scala
+++ b/src/test/scala/com/github/sstone/amqp/ConnectionOwnerSpec.scala
@@ -1,5 +1,7 @@
 package com.github.sstone.amqp
 
+import scala.collection.JavaConverters._
+
 import org.scalatest.{Matchers, WordSpecLike}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -9,7 +11,7 @@ import akka.pattern.gracefulStop
 import akka.util.Timeout
 import concurrent.duration._
 import concurrent.Await
-import com.rabbitmq.client.{Address, Channel, ConnectionFactory}
+import com.rabbitmq.client.{Address, Channel, ConnectionFactory, ListAddressResolver}
 import Amqp._
 import ConnectionOwner.{Connected, CreateChannel, Disconnected}
 import java.util.concurrent.TimeUnit
@@ -39,10 +41,10 @@ class ConnectionOwnerSpec extends TestKit(ActorSystem("TestSystem")) with WordSp
       connFactory.setUri(uri)
       val goodHost = connFactory.getHost
       connFactory.setHost("fake-host")
-      val conn = system.actorOf(ConnectionOwner.props(connFactory, addresses = Some(Array(
+      val conn = system.actorOf(ConnectionOwner.props(connFactory, addressResolver = Some(new ListAddressResolver(List(
           new Address("another.fake.host"),
           new Address(goodHost)
-        ))))
+        ).asJava))))
       Amqp.waitForConnection(system, conn).await(50, TimeUnit.SECONDS)
       val actors = 100
       for (i <- 0 until actors) {

--- a/src/test/scala/com/github/sstone/amqp/Test1.scala
+++ b/src/test/scala/com/github/sstone/amqp/Test1.scala
@@ -34,5 +34,5 @@ object Test1 extends App {
   // run the Producer sample now and see what happens
   println("press enter...")
   System.in.read()
-  system.shutdown()
+  system.terminate()
 }


### PR DESCRIPTION
Makes `ConnectionOwner` accept an `AddressResolver` instead of an array of addresses.