### PR TITLE
Allow binding to multiple routing keys

### DIFF
--- a/src/main/scala/com/github/sstone/amqp/Amqp.scala
+++ b/src/main/scala/com/github/sstone/amqp/Amqp.scala
@@ -75,7 +75,7 @@ object Amqp {
    */
   case class ChannelParameters(qos: Int, global: Boolean = false)
 
-  case class Binding(exchange: ExchangeParameters, queue: QueueParameters, routingKey: String)
+  case class Binding(exchange: ExchangeParameters, queue: QueueParameters, routingKeys: Set[String])
 
   /**
    * requests that can be sent to a ChannelOwner actor
@@ -84,7 +84,7 @@ object Amqp {
   sealed trait Request
 
   case class Abort(code: Int = AMQP.REPLY_SUCCESS, message: String = "OK") extends Request
-  
+
   case class AddStatusListener(listener: ActorRef) extends Request
 
   case class AddReturnListener(listener: ActorRef) extends Request
@@ -103,7 +103,7 @@ object Amqp {
 
   case class DeleteExchange(name: String, ifUnused: Boolean = false) extends Request
 
-  case class QueueBind(queue: String, exchange: String, routing_key: String, args: Map[String, AnyRef] = Map.empty) extends Request
+  case class QueueBind(queue: String, exchange: String, routingKeys: Set[String], args: Map[String, AnyRef] = Map.empty) extends Request
 
   case class QueueUnbind(queue: String, exchange: String, routing_key: String, args: Map[String, AnyRef] = Map.empty) extends Request
 

--- a/src/main/scala/com/github/sstone/amqp/ChannelOwner.scala
+++ b/src/main/scala/com/github/sstone/amqp/ChannelOwner.scala
@@ -1,16 +1,17 @@
 package com.github.sstone.amqp
 
 import collection.JavaConversions._
-import com.rabbitmq.client.AMQP.BasicProperties
+
+import com.rabbitmq.client.AMQP.{BasicProperties, Queue}
 import com.rabbitmq.client.{Delivery => _, _}
 import akka.actor._
 import com.github.sstone.amqp.Amqp._
 import scala.util.Try
 import scala.util.Failure
 import scala.util.Success
+
 import akka.event.LoggingReceive
 import scala.collection.mutable
-
 import java.util.UUID
 
 object ChannelOwner {
@@ -82,9 +83,9 @@ object ChannelOwner {
         log.debug("deleting queue {} ifUnused {} ifEmpty {}", queue, ifUnused, ifEmpty)
         sender ! withChannel(channel, request)(c => c.queueDelete(queue, ifUnused, ifEmpty))
       }
-      case request@QueueBind(queue, exchange, routingKey, args) => {
-        log.debug("binding queue {} to key {} on exchange {}", queue, routingKey, exchange)
-        sender ! withChannel(channel, request)(c => c.queueBind(queue, exchange, routingKey, args))
+      case request@QueueBind(queue, exchange, routingKeys, args) => {
+        log.debug("binding queue {} to keys {} on exchange {}", queue, routingKeys.mkString(", "), exchange)
+        sender ! withChannel(channel, request)(c => routingKeys.map(rk => c.queueBind(queue, exchange, rk, args)))
       }
       case request@QueueUnbind(queue, exchange, routingKey, args) => {
         log.debug("unbinding queue {} to key {} on exchange {}", queue, routingKey, exchange)

--- a/src/main/scala/com/github/sstone/amqp/RpcServer.scala
+++ b/src/main/scala/com/github/sstone/amqp/RpcServer.scala
@@ -31,7 +31,7 @@ object RpcServer {
 
     /**
      * create a message that describes why processing a request failed. You would typically serialize the exception along with
-     * some context information. 
+     * some context information.
      * @param delivery delivery which cause process() to throw an exception
      * @param e exception that was thrown in process()
      * @return a ProcessResult instance
@@ -43,10 +43,10 @@ object RpcServer {
     Props(new RpcServer(processor, init, channelParams))
 
   def props(queue: QueueParameters, exchange: ExchangeParameters, routingKey: String, proc: RpcServer.IProcessor, channelParams: ChannelParameters)(implicit ctx: ExecutionContext): Props =
-    props(processor = proc, init = List(AddBinding(Binding(exchange, queue, routingKey))), channelParams = Some(channelParams))
+    props(processor = proc, init = List(AddBinding(Binding(exchange, queue, Set(routingKey)))), channelParams = Some(channelParams))
 
   def props(queue: QueueParameters, exchange: ExchangeParameters, routingKey: String, proc: RpcServer.IProcessor)(implicit ctx: ExecutionContext): Props =
-    props(processor = proc, init = List(AddBinding(Binding(exchange, queue, routingKey))))
+    props(processor = proc, init = List(AddBinding(Binding(exchange, queue, Set(routingKey)))))
 
 }
 

--- a/src/main/scala/com/github/sstone/amqp/samples/Consumer1.scala
+++ b/src/main/scala/com/github/sstone/amqp/samples/Consumer1.scala
@@ -44,7 +44,7 @@ object Consumer1 extends App {
   val queueParams = QueueParameters("my_queue", passive = false, durable = false, exclusive = false, autodelete = true)
   consumer ! DeclareQueue(queueParams)
   // bind it
-  consumer ! QueueBind(queue = "my_queue", exchange = "amq.direct", routing_key = "my_key")
+  consumer ! QueueBind(queue = "my_queue", exchange = "amq.direct", routingKeys = Set("my_key"))
   // tell our consumer to consume from it
   consumer ! AddQueue(QueueParameters(name = "my_queue", passive = false))
 

--- a/src/main/scala/com/github/sstone/amqp/samples/Consumer2.scala
+++ b/src/main/scala/com/github/sstone/amqp/samples/Consumer2.scala
@@ -31,7 +31,7 @@ object Consumer2 extends App {
   // to the broker is lost and restored
   val consumer = ConnectionOwner.createChildActor(conn, Consumer.props(
     listener = Some(listener),
-    init = List(AddBinding(Binding(StandardExchanges.amqDirect, queueParams, "my_key")))
+    init = List(AddBinding(Binding(StandardExchanges.amqDirect, queueParams, Set("my_key"))))
   ), name = Some("consumer"))
 
   // wait till everyone is actually connected to the broker

--- a/src/main/scala/com/github/sstone/amqp/samples/Consumer3.scala
+++ b/src/main/scala/com/github/sstone/amqp/samples/Consumer3.scala
@@ -34,7 +34,7 @@ object Consumer3 extends App {
   // create a queue, bind it to a routing key and consume from it
   // here we wrap our requests inside a Record message, so will be replayed if the connection to
   // the broker is lost and restored
-  consumer ! Record(AddBinding(Binding(StandardExchanges.amqDirect, queueParams, "my_key")))
+  consumer ! Record(AddBinding(Binding(StandardExchanges.amqDirect, queueParams, Set("my_key"))))
 
   // run the Producer sample now and see what happens
   println("press enter...")

--- a/src/test/scala/com/github/sstone/amqp/Bug30Spec.scala
+++ b/src/test/scala/com/github/sstone/amqp/Bug30Spec.scala
@@ -20,7 +20,7 @@ object Bug30Spec {
       self,
       exchange = Amqp.StandardExchanges.amqDirect,
       queue = QueueParameters("my_queue", passive = false, durable = false, exclusive = false, autodelete = true),
-      routingKey = "my_key",
+      routingKeys = Set("my_key"),
       channelParams = None,
       autoack = false))
 

--- a/src/test/scala/com/github/sstone/amqp/ChannelOwnerSpec.scala
+++ b/src/test/scala/com/github/sstone/amqp/ChannelOwnerSpec.scala
@@ -27,7 +27,7 @@ class ChannelOwnerSpec extends ChannelSpec {
 
       // declare a queue, bind it to "my_test_key" on "amq.direct" and publish a message
       channelOwner ! DeclareQueue(QueueParameters(queue, passive = false, durable = false, autodelete = true))
-      channelOwner ! QueueBind(queue, "amq.direct", "my_test_key")
+      channelOwner ! QueueBind(queue, "amq.direct", Set("my_test_key"))
       channelOwner ! Publish("amq.direct", "my_test_key", "yo!".getBytes)
       receiveN(3, 2 seconds)
       Thread.sleep(100)

--- a/src/test/scala/com/github/sstone/amqp/ConsumerSpec.scala
+++ b/src/test/scala/com/github/sstone/amqp/ConsumerSpec.scala
@@ -33,7 +33,7 @@ class ConsumerSpec extends ChannelSpec {
       val exchange = ExchangeParameters(name = "amq.direct", exchangeType = "", passive = true)
       val queue = QueueParameters(name = "", passive = false, exclusive = true)
       ignoreMsg {
-        case Amqp.Ok(p:Publish, _) => true
+        case Amqp.Ok(p: Publish, _) => true
       }
       val probe = TestProbe()
       val consumer = ConnectionOwner.createChildActor(conn, Consumer.props(listener = Some(probe.ref)), timeout = 5000 millis)
@@ -46,12 +46,12 @@ class ConsumerSpec extends ChannelSpec {
       receiveOne(1 second)
 
       producer ! Publish(exchange.name, "my_key1", "yo, rk1!".getBytes)
-      probe.expectMsgPF(1.second){
-        case Delivery(_, envelope, _, body) if new String (body) == "yo, rk1!" && envelope.getRoutingKey == "my_key1" => // OK
+      probe.expectMsgPF(1.second) {
+        case Delivery(_, envelope, _, body) if new String(body) == "yo, rk1!" && envelope.getRoutingKey == "my_key1" => // OK
       }
       producer ! Publish(exchange.name, "my_key2", "yo, rk2!".getBytes)
-      probe.expectMsgPF(1.second){
-        case Delivery(_, envelope, _, body) if new String (body) == "yo, rk2!" && envelope.getRoutingKey == "my_key2" => // OK
+      probe.expectMsgPF(1.second) {
+        case Delivery(_, envelope, _, body) if new String(body) == "yo, rk2!" && envelope.getRoutingKey == "my_key2" => // OK
       }
     }
     "be able to set their channel's prefetch size" in {

--- a/src/test/scala/com/github/sstone/amqp/ConsumerSpec.scala
+++ b/src/test/scala/com/github/sstone/amqp/ConsumerSpec.scala
@@ -22,7 +22,7 @@ class ConsumerSpec extends ChannelSpec {
       producer ! AddStatusListener(probe.ref)
       probe.expectMsg(1 second, ChannelOwner.Connected)
       probe.expectMsg(1 second, ChannelOwner.Connected)
-      consumer ! AddBinding(Binding(exchange, queue, "my_key"))
+      consumer ! AddBinding(Binding(exchange, queue, Set("my_key")))
       val check = receiveOne(1 second)
       println(check)
       val message = "yo!".getBytes
@@ -68,7 +68,7 @@ class ConsumerSpec extends ChannelSpec {
       producer ! AddStatusListener(probe.ref)
       probe.expectMsg(1 second, ChannelOwner.Connected)
       probe.expectMsg(1 second, ChannelOwner.Connected)
-      consumer ! Record(AddBinding(Binding(exchange, queue, "my_key")))
+      consumer ! Record(AddBinding(Binding(exchange, queue, Set("my_key"))))
       val Amqp.Ok(AddBinding(_), _) = receiveOne(1 second)
 
       val message = "yo!".getBytes
@@ -98,7 +98,7 @@ class ConsumerSpec extends ChannelSpec {
       producer ! AddStatusListener(probe.ref)
       probe.expectMsg(1 second, ChannelOwner.Connected)
       probe.expectMsg(1 second, ChannelOwner.Connected)
-      consumer ! AddBinding(Binding(exchange, queue, "test_key"))
+      consumer ! AddBinding(Binding(exchange, queue, Set("test_key")))
       val Amqp.Ok(AddBinding(_), _) = receiveOne(1 second)
 
       // check that our exchange was created

--- a/src/test/scala/com/github/sstone/amqp/PendingAcksSpec.scala
+++ b/src/test/scala/com/github/sstone/amqp/PendingAcksSpec.scala
@@ -41,7 +41,7 @@ class PendingAcksSpec extends ChannelSpec with WordSpecLike {
       val producer = ConnectionOwner.createChildActor(conn, ChannelOwner.props())
       Amqp.waitForConnection(system, consumer, producer).await(1, TimeUnit.SECONDS)
 
-      consumer ! AddBinding(Binding(exchange, queue, routingKey))
+      consumer ! AddBinding(Binding(exchange, queue, Set(routingKey)))
       val Amqp.Ok(AddBinding(Binding(_, _, _)), _) = receiveOne(1 second)
 
       val message = "yo!".getBytes
@@ -71,7 +71,7 @@ class PendingAcksSpec extends ChannelSpec with WordSpecLike {
       Amqp.waitForConnection(system, consumer1).await(1, TimeUnit.SECONDS)
 
 
-      consumer1 ! AddBinding(Binding(exchange, queue, routingKey))
+      consumer1 ! AddBinding(Binding(exchange, queue, Set(routingKey)))
       val Amqp.Ok(AddBinding(Binding(_, _, _)), _) = receiveOne(1 second)
 
       // kill first consumer

--- a/src/test/scala/com/github/sstone/amqp/ProducerSpec.scala
+++ b/src/test/scala/com/github/sstone/amqp/ProducerSpec.scala
@@ -26,10 +26,10 @@ class ProducerSpec extends ChannelSpec {
       waitForConnection(system, conn, consumer, producer).await()
 
       // create a queue, bind it to "my_key" and consume from it
-      consumer ! AddBinding(Binding(exchange, queue, routingKey))
+      consumer ! AddBinding(Binding(exchange, queue, Set(routingKey)))
 
       fishForMessage(1 second) {
-        case Amqp.Ok(AddBinding(Binding(`exchange`, `queue`, `routingKey`)), _) => true
+        case Amqp.Ok(AddBinding(Binding(`exchange`, `queue`, routingKeys)), _) if routingKeys == Set(routingKey) => true
         case msg => {
           println(s"unexpected $msg")
           false
@@ -52,10 +52,10 @@ class ProducerSpec extends ChannelSpec {
       waitForConnection(system, conn, consumer, producer).await()
 
       // create a queue, bind it to our routing key and consume from it
-      consumer ! AddBinding(Binding(exchange, queue, routingKey))
+      consumer ! AddBinding(Binding(exchange, queue, Set(routingKey)))
 
       fishForMessage(1 second) {
-        case Amqp.Ok(AddBinding(Binding(`exchange`, `queue`, `routingKey`)), _) => true
+        case Amqp.Ok(AddBinding(Binding(`exchange`, `queue`, tal)), _) => true
         case _ => false
       }
 

--- a/src/test/scala/com/github/sstone/amqp/RpcSpec.scala
+++ b/src/test/scala/com/github/sstone/amqp/RpcSpec.scala
@@ -88,7 +88,7 @@ class RpcSpec extends ChannelSpec {
       val server = ConnectionOwner.createChildActor(conn, RpcServer.props(processor = proc), timeout = 2000.millis)
       val client = ConnectionOwner.createChildActor(conn, RpcClient.props(), timeout = 2000.millis)
       waitForConnection(system, conn, server, client).await(10, TimeUnit.SECONDS)
-      server ! AddBinding(Binding(exchange, queue, routingKey))
+      server ! AddBinding(Binding(exchange, queue, Set(routingKey)))
       val Amqp.Ok(AddBinding(_), _) = receiveOne(1 second)
 
       val myprops = new BasicProperties.Builder().contentType("my content").contentEncoding("my encoding").build()
@@ -125,7 +125,7 @@ class RpcSpec extends ChannelSpec {
       val routingKey = randomKey
       val server1 = ConnectionOwner.createChildActor(conn, RpcServer.props(proc1), timeout = 2000.millis)
       waitForConnection(system, conn, server1).await(5, TimeUnit.SECONDS)
-      server1 ! AddBinding(Binding(exchange, queue, routingKey))
+      server1 ! AddBinding(Binding(exchange, queue, Set(routingKey)))
       val Amqp.Ok(AddBinding(_), _) = receiveOne(1 second)
 
       val proc2 = new IProcessor {
@@ -135,7 +135,7 @@ class RpcSpec extends ChannelSpec {
       }
       val server2 = ConnectionOwner.createChildActor(conn, RpcServer.props(proc2), timeout = 2000.millis)
       waitForConnection(system, conn, server2).await(5, TimeUnit.SECONDS)
-      server2 ! AddBinding(Binding(exchange, queue, routingKey))
+      server2 ! AddBinding(Binding(exchange, queue, Set(routingKey)))
       val Amqp.Ok(AddBinding(_), _) = receiveOne(1 second)
 
       val client = ConnectionOwner.createChildActor(conn, RpcClient.props(), timeout = 2000.millis)

--- a/src/test/scala/com/github/sstone/amqp/Test1.scala
+++ b/src/test/scala/com/github/sstone/amqp/Test1.scala
@@ -26,7 +26,7 @@ object Test1 extends App {
 
   // we initialize our consumer with an AddBinding request: the queue and the binding will be recreated if the connection
   // to the broker is lost and restored
-  val consumer = ConnectionOwner.createChildActor(conn, Consumer.props(listener, StandardExchanges.amqDirect, queueParams, "my_key", channelParams = None, autoack = true))
+  val consumer = ConnectionOwner.createChildActor(conn, Consumer.props(listener, StandardExchanges.amqDirect, queueParams, Set("my_key"), channelParams = None, autoack = true))
 
   // wait till everyone is actually connected to the broker
   Amqp.waitForConnection(system, consumer).await()


### PR DESCRIPTION
This should allow bindings to multiple routing keys, tackling https://github.com/sstone/amqp-client/issues/68 and further working on https://github.com/sstone/amqp-client/pull/73.