### PR TITLE
Prevent channel leaks on connection lost

### DIFF
--- a/src/main/scala/com/github/sstone/amqp/ChannelOwner.scala
+++ b/src/main/scala/com/github/sstone/amqp/ChannelOwner.scala
@@ -218,9 +218,9 @@ class ChannelOwner(init: Seq[Request] = Seq.empty[Request], channelParams: Optio
     case Shutdown(cause) if !cause.isInitiatedByApplication => {
       log.error(cause, "shutdown")
       context.stop(forwarder)
-      // If the ConnectionOwner is sending us the shutdown signal, then a new channel will be created when it tries to
-      // reconnect. There's no need to explicitly ask for one.
-      if (sender != context.parent)
+      // If we get a connection closed, either via the `ConnectionOwner` or directly through the channel, we don't need
+      // to request a new channel, since a new one will be created when the `ConnectionOwner` tries to reconnect.
+      if (!cause.isHardError)
         context.parent ! ConnectionOwner.CreateChannel
       statusListeners.foreach(_ ! Disconnected)
       context.become(disconnected)

--- a/src/main/scala/com/github/sstone/amqp/ChannelOwner.scala
+++ b/src/main/scala/com/github/sstone/amqp/ChannelOwner.scala
@@ -235,7 +235,6 @@ class ChannelOwner(init: Seq[Request] = Seq.empty[Request], channelParams: Optio
       if (!cause.isHardError)
         context.parent ! ConnectionOwner.CreateChannel
       statusListeners.foreach(_ ! Disconnected)
-      log.info("Becoming disconnected")
       context.become(disconnected)
     }
   }

--- a/src/main/scala/com/github/sstone/amqp/ChannelOwner.scala
+++ b/src/main/scala/com/github/sstone/amqp/ChannelOwner.scala
@@ -181,40 +181,52 @@ class ChannelOwner(init: Seq[Request] = Seq.empty[Request], channelParams: Optio
 
   def receive = disconnected
 
-  def disconnected: Receive = LoggingReceive {
-    case channel: Channel => {
-      val forwarder = context.actorOf(Props(new Forwarder(channel)), name = "forwarder-" + UUID.randomUUID.toString)
-      forwarder ! AddShutdownListener(self)
-      forwarder ! AddReturnListener(self)
-      onChannel(channel, forwarder)
-      requestLog.foreach(r => self forward r)
-      log.info(s"got channel $channel")
-      statusListeners.foreach(_ ! Connected)
-      context.become(connected(channel, forwarder))
+  def newChannel(channel: Channel, previousForwarder: Option[ActorRef]) = {
+    log.info(s"got channel $channel")
+    previousForwarder.foreach { forwarder =>
+      context.stop(forwarder)
+      statusListeners.foreach(_ ! Disconnected)
     }
-    case Record(request: Request) => {
-      requestLog :+= request
+    val forwarder = context.actorOf(Props(new Forwarder(channel)), name = "forwarder-" + UUID.randomUUID.toString)
+    forwarder ! AddShutdownListener(self)
+    forwarder ! AddReturnListener(self)
+    Try(onChannel(channel, forwarder)) match {
+      case Success(_) =>
+        requestLog.foreach(r => self forward r)
+        if (previousForwarder.isEmpty)
+          statusListeners.foreach(_ ! Connected)
+        context.become(connected(channel, forwarder))
+      case Failure(exception) =>
+        log.error(exception, "onChannel")
+        context.stop(forwarder)
+        context.parent ! ConnectionOwner.CreateChannel
+        context.become(disconnected)
     }
-    case AddStatusListener(actor) => addStatusListener(actor)
+  }
 
-    case request: Request => {
+  def disconnected: Receive = LoggingReceive {
+    case channel: Channel =>
+      newChannel(channel, None)
+    case Record(request: Request) =>
+      requestLog :+= request
+    case AddStatusListener(actor) =>
+      addStatusListener(actor)
+    case request: Request =>
       sender ! NotConnectedError(request)
-    }
   }
 
   def connected(channel: Channel, forwarder: ActorRef): Receive = LoggingReceive {
     case Amqp.Ok(_, _) => ()
-    case Record(request: Request) => {
+    case Record(request: Request) =>
       requestLog :+= request
       self forward request
-    }
-    case AddStatusListener(listener) => {
+    case AddStatusListener(listener) =>
       addStatusListener(listener)
       listener ! Connected
-    }
-    case request: Request => {
+    case request: Request =>
       forwarder forward request
-    }
+    case c: Channel =>
+      newChannel(c, Some(forwarder))
     case Shutdown(cause) if !cause.isInitiatedByApplication => {
       log.error(cause, "shutdown")
       context.stop(forwarder)
@@ -223,6 +235,7 @@ class ChannelOwner(init: Seq[Request] = Seq.empty[Request], channelParams: Optio
       if (!cause.isHardError)
         context.parent ! ConnectionOwner.CreateChannel
       statusListeners.foreach(_ ! Disconnected)
+      log.info("Becoming disconnected")
       context.become(disconnected)
     }
   }

--- a/src/main/scala/com/github/sstone/amqp/ChannelOwner.scala
+++ b/src/main/scala/com/github/sstone/amqp/ChannelOwner.scala
@@ -193,8 +193,7 @@ class ChannelOwner(init: Seq[Request] = Seq.empty[Request], channelParams: Optio
     Try(onChannel(channel, forwarder)) match {
       case Success(_) =>
         requestLog.foreach(r => self forward r)
-        if (previousForwarder.isEmpty)
-          statusListeners.foreach(_ ! Connected)
+        statusListeners.foreach(_ ! Connected)
         context.become(connected(channel, forwarder))
       case Failure(exception) =>
         log.error(exception, "onChannel")

--- a/src/main/scala/com/github/sstone/amqp/ConnectionOwner.scala
+++ b/src/main/scala/com/github/sstone/amqp/ConnectionOwner.scala
@@ -139,11 +139,19 @@ class ConnectionOwner(connFactory: ConnectionFactory,
       log.debug(s"trying to connect ${toRedactedUri(connFactory)}")
       Try(createConnection) match {
         case Success(conn) => {
-          log.info(s"connected to ${toRedactedUri(connFactory)}")
-          statusListeners.foreach(_ ! Connected)
-          connection = Some(conn)
-          context.children.foreach(_ ! conn.createChannel())
-          context.become(connected(conn, context.children.toSet))
+          val channelAssignment = context.children.map(_ -> Try(conn.createChannel()))
+          // Only consider ourselves connected if we can create a channel for all of our children.
+          if (channelAssignment.forall(_._2.isSuccess)) {
+            log.info(s"connected to ${toRedactedUri(connFactory)}")
+            statusListeners.foreach(_ ! Connected)
+            connection = Some(conn)
+            // We know all Trys were successful, so it's safe to .get here.
+            channelAssignment.foreach { case (children, channel) => children ! channel.get }
+            context.become(connected(conn))
+          } else {
+            channelAssignment.foreach(_._2.map(_.close()))
+            conn.close()
+          }
         }
         case Failure(cause) => {
           log.error(cause, "connection failed")

--- a/src/main/scala/com/github/sstone/amqp/ConnectionOwner.scala
+++ b/src/main/scala/com/github/sstone/amqp/ConnectionOwner.scala
@@ -149,6 +149,7 @@ class ConnectionOwner(connFactory: ConnectionFactory,
             channelAssignment.foreach { case (children, channel) => children ! channel.get }
             context.become(connected(conn))
           } else {
+            log.error("failed to open channels for all children")
             channelAssignment.foreach(_._2.foreach(channel => Try(channel.close())))
             Try(conn.close())
           }

--- a/src/main/scala/com/github/sstone/amqp/ConnectionOwner.scala
+++ b/src/main/scala/com/github/sstone/amqp/ConnectionOwner.scala
@@ -141,7 +141,7 @@ class ConnectionOwner(connFactory: ConnectionFactory,
         case Success(conn) => {
           val channelAssignment = context.children.map(_ -> Try(conn.createChannel()))
           // Only consider ourselves connected if we can create a channel for all of our children.
-          if (channelAssignment.forall(_._2.fold(_ => false, _.isOpen))) {
+          if (channelAssignment.forall(_._2.map(_.isOpen).getOrElse(false))) {
             log.info(s"connected to ${toRedactedUri(connFactory)}")
             statusListeners.foreach(_ ! Connected)
             connection = Some(conn)

--- a/src/main/scala/com/github/sstone/amqp/ConnectionOwner.scala
+++ b/src/main/scala/com/github/sstone/amqp/ConnectionOwner.scala
@@ -122,8 +122,8 @@ class ConnectionOwner(connFactory: ConnectionFactory,
     conn.addShutdownListener(new ShutdownListener {
       def shutdownCompleted(cause: ShutdownSignalException): Unit = {
         self ! Shutdown(cause)
-        statusListeners.map(a => a ! Disconnected)
-       }
+        statusListeners.foreach(a => a ! Disconnected)
+      }
     })
     conn
   }
@@ -140,10 +140,10 @@ class ConnectionOwner(connFactory: ConnectionFactory,
       Try(createConnection) match {
         case Success(conn) => {
           log.info(s"connected to ${toRedactedUri(connFactory)}")
-          statusListeners.map(a => a ! Connected)
+          statusListeners.foreach(_ ! Connected)
           connection = Some(conn)
           context.children.foreach(_ ! conn.createChannel())
-          context.become(connected(conn))
+          context.become(connected(conn, context.children.toSet))
         }
         case Failure(cause) => {
           log.error(cause, "connection failed")
@@ -178,11 +178,11 @@ class ConnectionOwner(connFactory: ConnectionFactory,
       context.stop(self)
     }
     case CreateChannel => Try(conn.createChannel()) match {
-      case Success(channel) => sender ! channel
-      case Failure(cause) => {
+      case Success(channel) =>
+        sender ! channel
+      case Failure(cause) =>
         log.error(cause, "cannot create channel")
         context.become(disconnected)
-      }
     }
     case AddStatusListener(listener) => {
       addStatusListener(listener)


### PR DESCRIPTION
When the connection to the broker was lost, it was possible to leak a channel if both the `ChannelOwner` and `ConnectionOwner` handled the `Shutdown` message. In that case, the `ConnectionOwner` would create a new channel for children as part of its reconnect strategy, and the `ChannelOwner` would also request a new one, resulting in one more channel created than necessary.

This also improves the resilience of `ChannelOwner` and `ConnectionOwner` by:
* Only considering a connection good if channels for all children can be opened;
* Correctly handling new channels received by `ChannelOwners` while in the connected state;
* Handle failures in the `onChannel` callback as channel failures.